### PR TITLE
Better enum casting, memory cache and some minor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -362,3 +362,5 @@ dotnet_naming_style.s_camelcase.required_suffix =
 dotnet_naming_style.s_camelcase.word_separator = 
 dotnet_naming_style.s_camelcase.capitalization = camel_case
 
+# Diagnostic rules
+dotnet_diagnostic.RCS1049.severity = none       # Ignore simplefy boolean statements (e.g <value> is false)

--- a/src/Backend/BattleBitGraphQLApi/Extensions/HelperExtensions.cs
+++ b/src/Backend/BattleBitGraphQLApi/Extensions/HelperExtensions.cs
@@ -2,9 +2,10 @@ namespace BattleBitProxy.Backend.BattleBitGraphQLApi.Extensions;
 
 public static class HelperExtensions
 {
-    public static TEnum CastTo<TEnum>(this string value)
+    public static TEnum CastTo<TEnum>(this string value, TEnum defaultValue)
         where TEnum : struct, Enum
         => Enum.TryParse(value, out TEnum parsedValue)
-            ? parsedValue
-            : default(TEnum);
+            && Enum.IsDefined(typeof(TEnum), parsedValue)
+                ? parsedValue
+                : defaultValue;
 }

--- a/src/Backend/BattleBitGraphQLApi/Extensions/ServiceConfigurationExtensions.cs
+++ b/src/Backend/BattleBitGraphQLApi/Extensions/ServiceConfigurationExtensions.cs
@@ -8,6 +8,9 @@ public static class ServiceConfigurationExtensions
     public static WebApplicationBuilder ConfigureServices(
         this WebApplicationBuilder builder)
     {
+        // Register memory cache with tracking statistics enabled
+        builder.Services.AddMemoryCache(opt => opt.TrackStatistics = true);
+
         // Register needed BattleBitAPI services
         builder.Services.AddHttpClient(HttpClientName.BattleBitAPI, opt
             => opt.BaseAddress = new Uri("https://publicapi.battlebit.cloud"));

--- a/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/Types/GameModeType.cs
+++ b/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/Types/GameModeType.cs
@@ -9,6 +9,9 @@ public enum GameModeType
     [GraphQLDescription("Conquest")]
     CONQ,
 
+    [GraphQLDescription("CTF")]
+    CTF,
+
     [GraphQLDescription("Domination")]
     DOMI,
 


### PR DESCRIPTION
## Added rule to ignore simplefying boolean statements

This should no longer cause something like this (see code below) to be
flagged as a warning/problem by analyzers.

if (someType is false)

instead of recommended less read friendly format of

if (!someType)

----

## Added support for memory cache and default values casted enums

* Using .Net internal MemoryCache service to store all requests (for a
  limited time) towards BattleBits REST API. This should reduce number
  of requests being made, but also avoiding making multiple requests
  while using aliasas in GraphQL queries. This could've also been
    avoided by using dataloaders.

* Also added support for casting string as Enums with a default value
  from Enum type. Which means, if it fails during parsing process, it
  will just default back to specified default value.

	IMPORTANT: This means there will no longer be any exceptions being
	thrown if we're unable to parse the string as a enum type value.

* Moved over to GetFromJsonAsync instead of parsing objects manually.
  This should in practice mean better performance and possible error
  handling in the future.