### PR TITLE
Adds protection against introspection in production and staging

### DIFF
--- a/src/Backend/BattleBitGraphQLApi/Extensions/GraphQLExtensions.cs
+++ b/src/Backend/BattleBitGraphQLApi/Extensions/GraphQLExtensions.cs
@@ -12,6 +12,7 @@ internal static class GraphQLExtensions
         builder.Services
             .AddMemoryCache()       // Used by persisted queries pipeline
             .AddGraphQLServer()
+                .AllowIntrospection(builder.Environment.IsDevelopment())
                 .InitializeOnStartup()
                 .ModifyRequestOptions(opt =>
                 {


### PR DESCRIPTION
This small line will make sure we're only allowing introspection when running locally or in development mode.