### PR TITLE
Added initial support for dev container for this solution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:0-7.0",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// TODO: https is a bit wonky, read more about it here:
+	// ref: https://github.com/microsoft/vscode-remote-release/issues/6092
+	"forwardPorts": [7113, 5128, 7024, 5244],
+	"portsAttributes": {
+			"7113": {
+				"protocol": "https"
+			},
+            "7024": {
+                "protocol": "https"
+            }
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "dotnet restore",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "root"
+}

--- a/src/Backend/BattleBitGraphQLApi/Program.cs
+++ b/src/Backend/BattleBitGraphQLApi/Program.cs
@@ -9,7 +9,7 @@ builder
 
 var app = builder.Build();
 
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();
 
 // TODO: make configuration of this prettier
 app.UseCors(options => options


### PR DESCRIPTION
Only properly tested with GraphQL API and over http since https causes some wonky behavior of using local self-signed certificate.

Reference material used:
- [Trusting self-signed certificate in linux](https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-7.0&tabs=visual-studio%2Clinux-ubuntu#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos)
- [Reference project for using devcontainer](https://github.com/microsoft/vscode-remote-try-dotnet#enabling-https)
- [Github issue mentioning wonkyness of local self-signed certs in devcontainer](https://github.com/microsoft/vscode-remote-release/issues/6092)