### PR TITLE
Re-added tiny as a supported map size

### DIFF
--- a/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/Types/MapSizeType.cs
+++ b/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/Types/MapSizeType.cs
@@ -15,6 +15,9 @@ public enum MapSizeType
     [GraphQLDescription("64 players")]
     Medium,
 
-    [GraphQLDescription("32 players (smallest supported)")]
-    Small
+    [GraphQLDescription("32 players")]
+    Small,
+
+    [GraphQLDescription("Smallest supported mode")]
+    Tiny
 }


### PR DESCRIPTION
This size is usually not that common, but it still a supported map size which can occur in the API