### PR TITLE
Enabled filtering through mudselect components (region and gamemode)

### DIFF
--- a/src/Frontend/ServerExplorer/Pages/Index.razor
+++ b/src/Frontend/ServerExplorer/Pages/Index.razor
@@ -18,8 +18,7 @@
                     Variant="Variant.Outlined"
                     MultiSelection="true"
                     Clearable="true"
-                    @bind-Value="_gameModeValue"
-                    @bind-SelectedValues="_gameModeOptions">
+                    SelectedValuesChanged="OnGameModeChanged">
             @foreach (var mode in _gameModeList)
             {
                 <MudSelectItem T="string" Value="@mode">
@@ -35,8 +34,7 @@
                     Variant="Variant.Outlined"
                     MultiSelection="true"
                     Clearable="true"
-                    @bind-Value="_regionValue"
-                    @bind-SelectedValues="_regionOptions">
+                    SelectedValuesChanged="OnRegionChanged">
             @foreach (var region in _regionList)
             {
                 <MudSelectItem T="string" Value="region">
@@ -161,4 +159,16 @@
     private string _regionValue { get; set; } = "Nothing selected";
     private IEnumerable<string> _regionOptions { get; set; } = new HashSet<string>();
     private string[] _regionList => GetRegionList();
+
+    private void OnGameModeChanged(IEnumerable<string> gameModes)
+    {
+        _gameModes = Enum.GetValues<GameModeType>()
+            .Where(x => gameModes.Contains(x.ToString()) is false);
+    }
+
+    private void OnRegionChanged(IEnumerable<string> regions)
+    {
+        _regionTypes = Enum.GetValues<RegionType>()
+            .Where(x => regions.Contains(x.ToString()) is false);
+    }
 }


### PR DESCRIPTION
Due to some currently weird logic behind [UseFiltering] attribute in HotChocolate, we need to do a negative lookup for which gamemodes and regions which we're filtering on.

These changes will just add some simple loggic for handling this