### PR TITLE
Added support for using invariant string contains in queries

### DIFF
--- a/src/Backend/BattleBitGraphQLApi/Extensions/GraphQLExtensions.cs
+++ b/src/Backend/BattleBitGraphQLApi/Extensions/GraphQLExtensions.cs
@@ -1,5 +1,8 @@
+using BattleBitProxy.Backend.BattleBitGraphQLApi.GraphQL.Filters;
 using BattleBitProxy.Backend.BattleBitGraphQLApi.Services;
 
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
 using HotChocolate.Types.Pagination;
 
 namespace BattleBitProxy.Backend.BattleBitGraphQLApi.Extensions;
@@ -28,7 +31,12 @@ internal static class GraphQLExtensions
                 .UseAutomaticPersistedQueryPipeline()
             .AddInMemoryQueryStorage()
             .AddGraphQLTypes()
-            .AddFiltering()
+            .AddFiltering<CustomStringConventions>()
+                .AddConvention<IFilterConvention>(new FilterConventionExtension(
+                    x => x.AddProviderExtension(new QueryableFilterProviderExtension(
+                        p => p.AddFieldHandler<QueryableStringInvariantContainsHandler>()
+                    ))
+                ))
             .AddProjections()
             .AddSorting()
             .RegisterService<BattleBitAPIService>(ServiceKind.Resolver);

--- a/src/Backend/BattleBitGraphQLApi/GraphQL/Filters/CustomStringConventions.cs
+++ b/src/Backend/BattleBitGraphQLApi/GraphQL/Filters/CustomStringConventions.cs
@@ -1,0 +1,18 @@
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
+
+namespace BattleBitProxy.Backend.BattleBitGraphQLApi.GraphQL.Filters;
+
+public class CustomStringConventions : FilterConvention
+{
+    protected override void Configure(
+        IFilterConventionDescriptor descriptor)
+    {
+        descriptor.AddDefaults();
+
+        descriptor.Provider(
+            new QueryableFilterProvider(x =>
+                x.AddDefaultFieldHandlers()
+                    .AddFieldHandler<QueryableStringInvariantContainsHandler>()));
+    }
+}

--- a/src/Backend/BattleBitGraphQLApi/GraphQL/Filters/QueryableStringInvariantContainsHandler.cs
+++ b/src/Backend/BattleBitGraphQLApi/GraphQL/Filters/QueryableStringInvariantContainsHandler.cs
@@ -1,0 +1,48 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
+using HotChocolate.Language;
+
+namespace BattleBitProxy.Backend.BattleBitGraphQLApi.GraphQL.Filters;
+
+public class QueryableStringInvariantContainsHandler : QueryableStringOperationHandler
+{
+    private static readonly MethodInfo Contains =
+        typeof(string).GetMethod(
+            name: "IndexOf",
+            types: new[] {
+                typeof(string),
+                typeof(StringComparison)
+            }) ?? null!;
+
+    public QueryableStringInvariantContainsHandler(InputParser inputParser)
+        : base(inputParser) { }
+
+    protected override int Operation => DefaultFilterOperations.Contains;
+
+    public override Expression HandleOperation(
+        QueryableFilterContext context,
+        IFilterOperationField field,
+        IValueNode value,
+        object? parsedValue)
+    {
+        Expression property = context.GetInstance();
+
+        return parsedValue is string str
+            ? Expression.AndAlso(
+                Expression.NotEqual(
+                    left: property,
+                    right: Expression.Constant(null, typeof(object))),
+                Expression.NotEqual(
+                    left: Expression.Call(
+                        property,
+                        Contains,
+                        Expression.Constant(str),
+                        Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                    right: Expression.Constant(-1)))
+                ?? null!
+            : throw new InvalidOperationException();
+    }
+}


### PR DESCRIPTION
These changes was inspired by this discussion on github https://github.com/ChilliCream/graphql-platform/discussions/3915

Basically we're no longer matching strings extract, but instead always using string invariant case for everything (makes it easier for users to search for servers).