### PR TITLE
Renamed Clan to ClanName and fixed topclan query position and sort order

### DIFF
--- a/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/LeaderBoardInfo.cs
+++ b/src/Backend/BattleBitGraphQLApi/Models/GraphQLModels/LeaderBoardInfo.cs
@@ -35,7 +35,7 @@ public class LeaderBoardInfo
 
 public class TopClanObject
 {
-    public string Clan { get; set; } = null!;
+    public string ClanName { get; set; } = null!;
     public string Tag { get; set; } = null!;
     public int XP { get; set; }
     public int MaxPlayers { get; set; }

--- a/src/Backend/BattleBitGraphQLApi/Services/BattleBitAPIService.cs
+++ b/src/Backend/BattleBitGraphQLApi/Services/BattleBitAPIService.cs
@@ -151,15 +151,16 @@ public class BattleBitAPIService
                 {
                     TopClans = result
                         .SelectMany(e => e.TopClans)
+                        .OrderByDescending(e => int.TryParse(e.XP, out var xp) ? xp : 0)
                         .Select((e, i) => new TopClanObject
                         {
-                            Clan = e.Clan,
+                            ClanName = e.Clan,
                             Tag = e.Tag,
                             XP = int.TryParse(e.XP, out var xp) ? xp : 0,
                             MaxPlayers = int.TryParse(e.MaxPlayers, out var maxPlayers) ? maxPlayers : 0,
                             Position = i + 1
                         })
-                        .OrderByDescending(e => e.XP)
+                        .OrderBy(e => e.Position)
                         .ToList(),
 
                     MostXP = result


### PR DESCRIPTION
Previously it counted the position backwards, these changes will correct that and make sure we're always relying on XP for sorting.