### PR TITLE
Moved to centralized package management for nuget

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FluentValidation" Version="11.9.0" />
+    <PackageVersion Include="HotChocolate" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.AspNetCore.CommandLine" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.Data" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.PersistedQueries.FileSystem" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.PersistedQueries.InMemory" Version="13.9.0" />
+    <PackageVersion Include="HotChocolate.Types.Analyzers" Version="13.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Backend/BattleBitGraphQLApi/BattleBitGraphQLApi.csproj
+++ b/src/Backend/BattleBitGraphQLApi/BattleBitGraphQLApi.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.9.0" />
-    <PackageReference Include="HotChocolate" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.Data" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.PersistedQueries.FileSystem" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="13.9.0" />
-    <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="HotChocolate" />
+    <PackageReference Include="HotChocolate.AspNetCore" />
+    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" />
+    <PackageReference Include="HotChocolate.Data" />
+    <PackageReference Include="HotChocolate.PersistedQueries.FileSystem" />
+    <PackageReference Include="HotChocolate.PersistedQueries.InMemory" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This should make it easier to keep track of used packages and their versions throughout all registered projects.

ref: https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management